### PR TITLE
Adding the option to sort the output per entry

### DIFF
--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -218,7 +218,7 @@ module SeedMigration
 ActiveRecord::Base.transaction do
         eos
         SeedMigration.registrar.each do |register_entry|
-          register_entry.model.order('id').each do |instance|
+          register_entry.model.order(register_entry.order).each do |instance|
             file.write generate_model_creation_string(instance, register_entry)
           end
 

--- a/lib/seed_migration/register_entry.rb
+++ b/lib/seed_migration/register_entry.rb
@@ -1,7 +1,10 @@
 module SeedMigration
   class RegisterEntry
+    DEFAULT_ORDER = 'id'
+
     attr_reader :model
     attr_accessor :attributes
+    attr_accessor :ordering
 
     def initialize(model)
       @model = model
@@ -12,12 +15,16 @@ module SeedMigration
       attrs.map(&:to_s).each { |attr| exclude_single_attributes attr }
     end
 
-    def eql?(object)
-      object.class == self.class && object.model == self.model
+    def eql?(other)
+      other.class == self.class && other.model == self.model
     end
 
     def hash
       model.hash
+    end
+
+    def order(order=DEFAULT_ORDER)
+      @order ||= order
     end
 
     private

--- a/spec/lib/migrator_spec.rb
+++ b/spec/lib/migrator_spec.rb
@@ -157,7 +157,9 @@ describe SeedMigration::Migrator do
       before(:all) do
         SeedMigration.ignore_ids = false
         SeedMigration.update_seeds_file = true
-        SeedMigration.register User
+        SeedMigration.register User do
+          order :username
+        end
         SeedMigration.register Product
       end
 

--- a/spec/lib/register_entry_spec.rb
+++ b/spec/lib/register_entry_spec.rb
@@ -41,4 +41,19 @@ describe SeedMigration::RegisterEntry do
       end
     end
   end
+
+  describe '#ordering' do
+    context 'given no arguments' do
+      it 'sets the ordering to the default' do
+        entry.order.should eq('id')
+      end
+    end
+
+    context 'given ordering arguments' do
+      it 'sets the ordering to the passed ordering' do
+        entry.order :example
+        entry.order.should eq(:example)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The requirement is for the entry to be output to the seeds file in the
order speicified in the initializer rather than the default 'id' being
used.
